### PR TITLE
systemd>229: StartLimit's moved to Unit

### DIFF
--- a/docker/compose.service.template
+++ b/docker/compose.service.template
@@ -3,6 +3,8 @@
 Description=__SERVICE__
 Requires=docker.service
 After=docker.service
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 WorkingDirectory=__WORKDIR__
@@ -10,8 +12,6 @@ ExecStart=/usr/bin/docker compose up
 ExecStop=/usr/bin/docker compose down
 TimeoutStartSec=0
 Restart=on-failure
-StartLimitIntervalSec=60
-StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd241 on the old pi

```
$ systemd --version
systemd 241 (241)
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid
```
